### PR TITLE
docs: Include theme attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Badge size.
 
 Validation callback.
 
+#### theme
+
+* Type: **string**
+* Required: **no**
+* Values: **light**, **dark**
+* Default value: **light**
+
 ## Copyright
 
 (c) 2020, Pittaca S.r.l.s.


### PR DESCRIPTION
The plugin already includes support for the theme attribute, it's just not documented on this readme.

:)